### PR TITLE
fixed bug that caused nginx test to fail.

### DIFF
--- a/odoo_nginx_conf
+++ b/odoo_nginx_conf
@@ -9,7 +9,7 @@ server 127.0.0.1:8072;
 
 server {
 listen 80;
-odoomates.tech www.odoomates.tech;
+server_name odoomates.tech www.odoomates.tech;
 
 proxy_read_timeout 720s;
 proxy_connect_timeout 720s;


### PR DESCRIPTION
Abscence of server name caused nginx test to fail, fixed by adding the server name.